### PR TITLE
add exclusion for "posts you've liked" page

### DIFF
--- a/cohost-dedup.user.js
+++ b/cohost-dedup.user.js
@@ -11,6 +11,7 @@
 // @exclude https://cohost.org/rc/project/*
 // @exclude https://cohost.org/rc/user/*
 // @exclude https://cohost.org/rc/posts/unpublished*
+// @exclude https://cohost.org/rc/liked-posts
 // ==/UserScript==
 
 // Should be compatible with Firefox (desktop and mobile) and Chrome. To use,

--- a/cohost-dedup.user.js
+++ b/cohost-dedup.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name Cohost Dedup
 // @namespace https://nex-3.com
-// @version 1.3
+// @version 1.4
 // @description Deduplicate posts you've already seen on Cohost
 // @author Natalie Weizenbaum
 // @match https://cohost.org/*


### PR DESCRIPTION
went a little batty trying to find a post i knew i liked but couldn't find, thought maybe it was deleted, but turned out dedup was just hiding it from me on the liked posts page!