### PR TITLE
add exclusion for tag search results pages

### DIFF
--- a/cohost-dedup.user.js
+++ b/cohost-dedup.user.js
@@ -10,6 +10,7 @@
 // @exclude https://cohost.org/rc/search
 // @exclude https://cohost.org/rc/project/*
 // @exclude https://cohost.org/rc/user/*
+// @exclude https://cohost.org/rc/tagged/*
 // @exclude https://cohost.org/rc/posts/unpublished*
 // @exclude https://cohost.org/rc/liked-posts
 // ==/UserScript==


### PR DESCRIPTION
noticed when clicking through tags that when going back to a previous tag, results were suddenly missing!